### PR TITLE
Fix culling when rendering translucent/transparent terrain and add CTM support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,10 @@ dependencies {
     implementation("mekanism:Mekanism:${mekanism_version}:additions")
     implementation("mekanism:Mekanism:${mekanism_version}:generators")
     implementation("mekanism:Mekanism:${mekanism_version}:tools")
+
+    runtimeOnly("maven.modrinth:athena-ctm:4.0.1")
+    runtimeOnly("maven.modrinth:chipped:4.0.2")
+    runtimeOnly("maven.modrinth:resourceful-lib:3.0.11")
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCovers.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCovers.java
@@ -29,6 +29,7 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.neoforge.client.model.data.ModelData;
 import net.neoforged.neoforge.client.model.data.ModelProperty;
 import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
 import net.neoforged.fml.common.Mod;
@@ -52,6 +53,8 @@ public class MekanismCovers {
     public static final DeferredHolder<RecipeSerializer<?>, SimpleCraftingRecipeSerializer<CoverRecipe>> COVER_SERIALIZER = RECIPE_SERIALIZERS.register("crafting_special_cover", () -> new SimpleCraftingRecipeSerializer<>(CoverRecipe::new));
 
     public static final ModelProperty<BlockState> COVER_STATE = new ModelProperty<>();
+    public static final ModelProperty<ModelData> COVER_DATA = new ModelProperty<>();
+
 
     public MekanismCovers(IEventBus modEventBus, ModContainer modContainer) {
         ITEMS.register(modEventBus);
@@ -98,5 +101,4 @@ public class MekanismCovers {
             return null;
         }
     }
-
 }

--- a/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
@@ -9,11 +9,13 @@ import mekanism.common.util.WorldUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
@@ -23,6 +25,8 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.ModelEvent;
 import net.neoforged.neoforge.client.event.RegisterColorHandlersEvent;
 import net.neoforged.neoforge.client.extensions.common.RegisterClientExtensionsEvent;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.jetbrains.annotations.NotNull;
 
 import static dev.lucaargolo.mekanismcovers.MekanismCovers.MODID;
 
@@ -171,4 +175,8 @@ public class MekanismCoversClient {
         }
     }
 
+    @NotNull
+    public static ModelData getModelData(BlockState state, BlockAndTintGetter level, BlockPos worldPosition) {
+        return Minecraft.getInstance().getBlockRenderer().getBlockModel(state).getModelData(level, worldPosition, state, ModelData.EMPTY);
+    }
 }

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/BlockTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/BlockTransmitterMixin.java
@@ -9,11 +9,14 @@ import mekanism.common.registries.MekanismItems;
 import mekanism.common.tile.transmitter.TileEntityTransmitter;
 import mekanism.common.util.WorldUtils;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -65,4 +68,12 @@ public abstract class BlockTransmitterMixin extends BlockMekanism implements ISt
         return true;
     }
 
+    @Override
+    public BlockState getAppearance(BlockState state, BlockAndTintGetter level, BlockPos pos, Direction side, @Nullable BlockState queryState, @Nullable BlockPos queryPos) {
+        TileEntityTransmitter tile = WorldUtils.getTileEntity(TileEntityTransmitter.class, level, pos);
+        if(tile instanceof TileEntityTransmitterMixed transmitter && transmitter.mekanism_covers$getCoverState() != null) {
+            return transmitter.mekanism_covers$getCoverState();
+        }
+        return super.getAppearance(state, level, pos, side, queryState, queryPos);
+    }
 }

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/ClientBlockTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/ClientBlockTransmitterMixin.java
@@ -6,20 +6,24 @@ import mekanism.common.block.transmitter.BlockTransmitter;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import net.neoforged.neoforge.client.ChunkRenderTypeSet;
 import net.neoforged.neoforge.client.model.data.ModelData;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(BlockTransmitter.class)
 public class ClientBlockTransmitterMixin {
+
+    @Unique
+    private static final RandomSource RAND = RandomSource.create();
 
     @Inject(method = "getOcclusionShape", at = @At("RETURN"), cancellable = true)
     private void wrapOcclusion(BlockState state, BlockGetter world, BlockPos pos, CallbackInfoReturnable<VoxelShape> cir) {
@@ -30,7 +34,7 @@ public class ClientBlockTransmitterMixin {
         if (state.getBlock() instanceof BlockTransmitter && world.getBlockEntity(pos) instanceof TileEntityTransmitterMixed transmitter) {
             if (transmitter.mekanism_covers$getCoverState() != null) {
                 var model = Minecraft.getInstance().getBlockRenderer().getBlockModel(transmitter.mekanism_covers$getCoverState());
-                ChunkRenderTypeSet renderTypes = model.getRenderTypes(transmitter.mekanism_covers$getCoverState(), new XoroshiroRandomSource(123456789), ModelData.EMPTY);
+                ChunkRenderTypeSet renderTypes = model.getRenderTypes(transmitter.mekanism_covers$getCoverState(), RAND, ModelData.EMPTY);
                 if (renderTypes.contains(RenderType.translucent()) || renderTypes.contains(RenderType.CUTOUT) || renderTypes.contains(RenderType.CUTOUT_MIPPED)) {
                     cir.setReturnValue(Shapes.empty());
                 }

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/ClientBlockTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/ClientBlockTransmitterMixin.java
@@ -1,0 +1,40 @@
+package dev.lucaargolo.mekanismcovers.mixin;
+
+import dev.lucaargolo.mekanismcovers.MekanismCoversClient;
+import dev.lucaargolo.mekanismcovers.mixed.TileEntityTransmitterMixed;
+import mekanism.common.block.transmitter.BlockTransmitter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.RenderType;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.XoroshiroRandomSource;
+import net.minecraft.world.phys.shapes.Shapes;
+import net.minecraft.world.phys.shapes.VoxelShape;
+import net.neoforged.neoforge.client.ChunkRenderTypeSet;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(BlockTransmitter.class)
+public class ClientBlockTransmitterMixin {
+
+    @Inject(method = "getOcclusionShape", at = @At("RETURN"), cancellable = true)
+    private void wrapOcclusion(BlockState state, BlockGetter world, BlockPos pos, CallbackInfoReturnable<VoxelShape> cir) {
+        if (MekanismCoversClient.isCoverTransparentFast()) {
+            cir.setReturnValue(Shapes.empty());
+            return;
+        }
+        if (state.getBlock() instanceof BlockTransmitter && world.getBlockEntity(pos) instanceof TileEntityTransmitterMixed transmitter) {
+            if (transmitter.mekanism_covers$getCoverState() != null) {
+                var model = Minecraft.getInstance().getBlockRenderer().getBlockModel(transmitter.mekanism_covers$getCoverState());
+                ChunkRenderTypeSet renderTypes = model.getRenderTypes(transmitter.mekanism_covers$getCoverState(), new XoroshiroRandomSource(123456789), ModelData.EMPTY);
+                if (renderTypes.contains(RenderType.translucent()) || renderTypes.contains(RenderType.CUTOUT) || renderTypes.contains(RenderType.CUTOUT_MIPPED)) {
+                    cir.setReturnValue(Shapes.empty());
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
@@ -35,14 +35,9 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
         super(type, pos, state);
     }
 
-    @SuppressWarnings({"DataFlowIssue", "rawtypes", "unchecked"})
     @Inject(at = @At("RETURN"), method = "getModelData", cancellable = true, remap = false)
     public void injectCoverModel(CallbackInfoReturnable<ModelData> cir) {
-        ModelData data = cir.getReturnValue();
-        ModelData.Builder builder = ModelData.builder();
-        for(ModelProperty property : data.getProperties()) {
-            builder.with(property, data.get(property));
-        }
+        ModelData.Builder builder = cir.getReturnValue().derive();
         if(this.mekanism_covers$coverState != null) {
             builder.with(MekanismCovers.COVER_STATE, this.mekanism_covers$coverState);
         }

--- a/src/main/resources/mekanismcovers.mixins.json
+++ b/src/main/resources/mekanismcovers.mixins.json
@@ -22,7 +22,8 @@
     "MinecraftMixin",
     "BakedQuadAccessor",
     "ModelBlockRendererMixin",
-    "TransmitterBakedModelMixin"
+    "TransmitterBakedModelMixin",
+    "ClientBlockTransmitterMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
When rendering covers, currently the "block" shape is being used for occlusion. However if the block is translucent or transparent, this makes it so you can look through the world. By making it return an "empty" shape for culling when rendering translucent/transparent blocks, this is fixed.

I've put it in a new clientside mixin, as it uses client only classes. I was unable to launch the server due to a sodium issue, but this should make it safe to use on servers.

Secondly, this also adds the ability for connected textures on covers

Fixes #4 