### PR TITLE
Add an alternate shader compatible renderer for translucent cover rendering

### DIFF
--- a/src/main/java/dev/lucaargolo/mekanismcovers/ClientEvents.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/ClientEvents.java
@@ -1,0 +1,73 @@
+package dev.lucaargolo.mekanismcovers;
+
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import dev.lucaargolo.mekanismcovers.mixed.TileEntityTransmitterMixed;
+import mekanism.common.block.transmitter.BlockTransmitter;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.client.renderer.LightTexture;
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.model.data.ModelData;
+import net.neoforged.neoforge.client.model.pipeline.VertexConsumerWrapper;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+
+import java.util.Map;
+
+@EventBusSubscriber(bus = EventBusSubscriber.Bus.GAME, value = Dist.CLIENT)
+public class ClientEvents {
+
+    @SubscribeEvent
+    static void renderLevel(RenderLevelStageEvent event) {
+        if (!MekanismCoversClient.SHADER_COVER_RENDERING || !MekanismCoversClient.isCoverTransparentFast()) {
+            return;
+        }
+        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS) {
+            for (Map.Entry<BlockPos, BlockState> entry : MekanismCovers.POSSIBLE_BLOCKS.entrySet()) {
+                ClientLevel level = Minecraft.getInstance().level;
+                if (level.getBlockState(entry.getKey()).getBlock() instanceof BlockTransmitter<?>) {
+                    if (entry.getValue() == null) {
+                        continue;
+                    }
+
+                    var baseConsumer = Minecraft.getInstance().renderBuffers().bufferSource().getBuffer(Sheets.translucentCullBlockSheet());
+                    var wrappedConsumer = new VertexConsumerWrapper(baseConsumer) {
+                        @Override
+                        public VertexConsumer setColor(int r, int g, int b, int a) {
+                            super.setColor(r, g, b, 120);
+                            return this;
+                        }
+                    };
+
+                    var cameraPos = event.getCamera().getPosition();
+                    event.getPoseStack().pushPose();
+                    event.getPoseStack().translate(entry.getKey().getX()-cameraPos.x, entry.getKey().getY()-cameraPos.y, entry.getKey().getZ()-cameraPos.z);
+
+                    var model = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(entry.getValue());
+                    for (var renderType : model.getRenderTypes(entry.getValue(), RandomSource.create(), ModelData.EMPTY)) {
+                        Minecraft.getInstance().getBlockRenderer().getModelRenderer().renderModel(event.getPoseStack().last(), wrappedConsumer, entry.getValue(),
+                                model, 1f, 1f, 1f, LightTexture.pack(level.getBrightness(LightLayer.BLOCK, entry.getKey()), level.getBrightness(LightLayer.SKY, entry.getKey())),
+                                OverlayTexture.NO_OVERLAY, model.getModelData(level, entry.getKey(), entry.getValue(), ModelData.EMPTY), renderType
+                        );
+                    }
+                    event.getPoseStack().popPose();
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    static void changeDimension(PlayerEvent.PlayerChangedDimensionEvent event) {
+        if (event.getEntity() == Minecraft.getInstance().player) {
+            MekanismCovers.POSSIBLE_BLOCKS.clear();
+        }
+    }
+}

--- a/src/main/java/dev/lucaargolo/mekanismcovers/ClientEvents.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/ClientEvents.java
@@ -27,14 +27,17 @@ public class ClientEvents {
 
     @SubscribeEvent
     static void renderLevel(RenderLevelStageEvent event) {
-        if (!MekanismCoversClient.SHADER_COVER_RENDERING || !MekanismCoversClient.isCoverTransparentFast()) {
+        if(!MekanismCoversClient.SHADER_COVER_RENDERING || !MekanismCoversClient.isCoverTransparentFast() || !MekanismCoversClient.hasShaderPack()) {
             return;
         }
-        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS) {
-            for (Map.Entry<BlockPos, BlockState> entry : MekanismCovers.POSSIBLE_BLOCKS.entrySet()) {
+        if(event.getStage() == RenderLevelStageEvent.Stage.AFTER_TRIPWIRE_BLOCKS) {
+            for(Map.Entry<BlockPos, BlockState> entry : MekanismCovers.POSSIBLE_BLOCKS.entrySet()) {
                 ClientLevel level = Minecraft.getInstance().level;
-                if (level.getBlockState(entry.getKey()).getBlock() instanceof BlockTransmitter<?>) {
-                    if (entry.getValue() == null) {
+                if(!level.isLoaded(entry.getKey())) {
+                    return;
+                }
+                if(level.getBlockState(entry.getKey()).getBlock() instanceof BlockTransmitter<?>) {
+                    if(entry.getValue() == null) {
                         continue;
                     }
 
@@ -52,7 +55,7 @@ public class ClientEvents {
                     event.getPoseStack().translate(entry.getKey().getX()-cameraPos.x, entry.getKey().getY()-cameraPos.y, entry.getKey().getZ()-cameraPos.z);
 
                     var model = Minecraft.getInstance().getModelManager().getBlockModelShaper().getBlockModel(entry.getValue());
-                    for (var renderType : model.getRenderTypes(entry.getValue(), RandomSource.create(), ModelData.EMPTY)) {
+                    for(var renderType : model.getRenderTypes(entry.getValue(), RandomSource.create(), ModelData.EMPTY)) {
                         Minecraft.getInstance().getBlockRenderer().getModelRenderer().renderModel(event.getPoseStack().last(), wrappedConsumer, entry.getValue(),
                                 model, 1f, 1f, 1f, LightTexture.pack(level.getBrightness(LightLayer.BLOCK, entry.getKey()), level.getBrightness(LightLayer.SKY, entry.getKey())),
                                 OverlayTexture.NO_OVERLAY, model.getModelData(level, entry.getKey(), entry.getValue(), ModelData.EMPTY), renderType

--- a/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCovers.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCovers.java
@@ -32,6 +32,9 @@ import net.neoforged.neoforge.registries.DeferredHolder;
 import net.neoforged.neoforge.registries.DeferredRegister;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Mod(MekanismCovers.MODID)
 public class MekanismCovers {
 
@@ -50,6 +53,7 @@ public class MekanismCovers {
     public static final ModelProperty<BlockState> COVER_STATE = new ModelProperty<>();
     public static final ModelProperty<ModelData> COVER_DATA = new ModelProperty<>();
 
+    public static final Map<BlockPos, BlockState> POSSIBLE_BLOCKS = new HashMap<>();
 
     public MekanismCovers(IEventBus modEventBus, ModContainer modContainer) {
         ITEMS.register(modEventBus);

--- a/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
@@ -37,7 +37,8 @@ import static dev.lucaargolo.mekanismcovers.MekanismCovers.MODID;
 public class MekanismCoversClient {
 
     public static final boolean ADVANCED_COVER_RENDERING = !ModConfig.getInstance().isDisableAdvancedCoverRendering();
-    
+    public static final boolean SHADER_COVER_RENDERING = ModConfig.getInstance().isEnableShaderCompatibleRendering();
+
     private static boolean lastTransparency = false;
 
     public static final ModelResourceLocation COVER_MODEL = ModelResourceLocation.standalone(ResourceLocation.fromNamespaceAndPath(MODID, "block/cover"));

--- a/src/main/java/dev/lucaargolo/mekanismcovers/ModConfig.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/ModConfig.java
@@ -25,13 +25,22 @@ public class ModConfig {
     private static final Gson GSON = new Gson().newBuilder().setPrettyPrinting().create();
 
     private boolean disableAdvancedCoverRendering = false;
+    private boolean enableShaderCompatibleRendering = false;
 
     public boolean isDisableAdvancedCoverRendering() {
         return disableAdvancedCoverRendering;
     }
 
+    public boolean isEnableShaderCompatibleRendering() {
+        return enableShaderCompatibleRendering;
+    }
+
     public void setDisableAdvancedCoverRendering(boolean disableAdvancedLayer) {
         this.disableAdvancedCoverRendering = disableAdvancedLayer;
+    }
+
+    public void setShaderCompatibleRendering(boolean enable) {
+        this.enableShaderCompatibleRendering = enable;
     }
 
     public void save() {

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
@@ -92,6 +92,11 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
         }
     }
 
+    @Inject(at = @At(value = "INVOKE", target = "Lmekanism/common/content/network/transmitter/Transmitter;setTransmitterNetwork(Lmekanism/common/lib/transmitter/DynamicNetwork;)V"), method = "onWorldSeparate")
+    public void injectUnload(boolean stillPresent, CallbackInfo ci) {
+        MekanismCovers.POSSIBLE_BLOCKS.remove(this.worldPosition);
+    }
+
     @Override
     public void mekanism_covers$onUpdateClient() {
         if (this.mekanism_covers$updateClientLight) {

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
@@ -84,9 +84,11 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
             String serialized = tag.getString("CoverState");
             BlockStateParser.BlockResult result = BlockStateParser.parseForBlock(BuiltInRegistries.BLOCK.asLookup(), serialized, false);
             this.mekanism_covers$coverState = result.blockState();
+            MekanismCovers.POSSIBLE_BLOCKS.put(this.worldPosition, this.mekanism_covers$coverState);
             this.mekanism_covers$updateClientLight = true;
         }catch (Exception exception) {
             this.mekanism_covers$coverState = null;
+            MekanismCovers.POSSIBLE_BLOCKS.remove(this.worldPosition);
         }
     }
 

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TransmitterBakedModelMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TransmitterBakedModelMixin.java
@@ -50,7 +50,9 @@ public class TransmitterBakedModelMixin extends BakedModelWrapper<BakedModel> {
                             List<BakedQuad> coverQuads = bakedModel.getQuads(coverState, side, rand, data, renderType);
                             Stream<BakedQuad> copiedQuads = coverQuads.stream().map(q -> new BakedQuad(q.getVertices(), q.isTinted() ? 1337 : 1338, q.getDirection(), q.getSprite(), q.isShade(), q.hasAmbientOcclusion()));
                             cir.setReturnValue(Stream.concat(originalQuads.stream(), copiedQuads).toList());
-                        }else{
+                        }else if (MekanismCoversClient.SHADER_COVER_RENDERING && MekanismCoversClient.hasShaderPack()) {
+                            cir.cancel();
+                        }else {
                             BakedModel altModel = minecraft.getModelManager().getModel(MekanismCoversClient.COVER_MODEL);
                             List<BakedQuad> altQuads = altModel.getQuads(Blocks.AIR.defaultBlockState(), side, rand, extraData, renderType);
                             cir.setReturnValue(Stream.concat(originalQuads.stream(), altQuads.stream()).toList());


### PR DESCRIPTION
The current way of handeling the translucent rendering when holding a pipe is probably the best way of doing it. However, shaders currently do not respect vertex alpha values, making it so it doesn't work when shaders are active. I've added here an alternative renderer that does work with shaders.

Some information about it:
- The RenderLevelEvent with the tripwire stage is used for translucency sorting
- A VertexConsumerWrapper is used to control the alpha value
- A map with positions and states is used to provide data for the renderer
  - This should be fully working and server safe, but do please double check it

I've locked it behind a setting, and will only be active if the setting is on and shaders are active