### PR TITLE
Fix Sodium 0.8 crash and cover render refresh

### DIFF
--- a/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/MekanismCoversClient.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BlockItem;
@@ -97,6 +98,14 @@ public class MekanismCoversClient {
 
     public static boolean isCoverTransparentFast() {
         return lastTransparency;
+    }
+
+    public static void markCoverSectionDirty(BlockPos pos) {
+        Minecraft.getInstance().levelRenderer.setSectionDirty(
+                SectionPos.blockToSectionCoord(pos.getX()),
+                SectionPos.blockToSectionCoord(pos.getY()),
+                SectionPos.blockToSectionCoord(pos.getZ())
+        );
     }
 
     private static boolean isCoverTransparent() {

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/TileEntityTransmitterMixin.java
@@ -1,6 +1,7 @@
 package dev.lucaargolo.mekanismcovers.mixin;
 
 import dev.lucaargolo.mekanismcovers.MekanismCovers;
+import dev.lucaargolo.mekanismcovers.MekanismCoversClient;
 import dev.lucaargolo.mekanismcovers.mixed.TileEntityTransmitterMixed;
 import mekanism.api.IAlloyInteraction;
 import mekanism.common.capabilities.proxy.ProxyConfigurable;
@@ -23,6 +24,8 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.Objects;
+
 @Mixin(value = TileEntityTransmitter.class)
 public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity implements ProxyConfigurable.ISidedConfigurable, IAlloyInteraction, TileEntityTransmitterMixed {
 
@@ -30,6 +33,8 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
     private BlockState mekanism_covers$coverState = null;
     @Unique
     private boolean mekanism_covers$updateClientLight = false;
+    @Unique
+    private boolean mekanism_covers$updateClientRender = false;
 
     public TileEntityTransmitterMixin(TileEntityTypeRegistryObject<?> type, BlockPos pos, BlockState state) {
         super(type, pos, state);
@@ -80,6 +85,7 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
 
     @Inject(at = @At("TAIL"), method = "handleUpdateTag", remap = false)
     public void injectUpdateTag(CompoundTag tag, HolderLookup.Provider provider, CallbackInfo ci) {
+        BlockState previousCover = this.mekanism_covers$coverState;
         try {
             String serialized = tag.getString("CoverState");
             BlockStateParser.BlockResult result = BlockStateParser.parseForBlock(BuiltInRegistries.BLOCK.asLookup(), serialized, false);
@@ -89,6 +95,9 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
         }catch (Exception exception) {
             this.mekanism_covers$coverState = null;
             MekanismCovers.POSSIBLE_BLOCKS.remove(this.worldPosition);
+        }
+        if (!Objects.equals(previousCover, this.mekanism_covers$coverState)) {
+            this.mekanism_covers$updateClientRender = true;
         }
     }
 
@@ -108,6 +117,13 @@ public abstract class TileEntityTransmitterMixin extends CapabilityTileEntity im
                 this.level.getLightEngine().checkBlock(this.worldPosition);
                 this.mekanism_covers$updateClientLight = !this.level.getLightEngine().lightOnInSection(SectionPos.of(this.worldPosition));
             }
+        }
+        if (this.mekanism_covers$updateClientRender) {
+            this.requestModelDataUpdate();
+            if (this.level != null && this.level.isClientSide) {
+                MekanismCoversClient.markCoverSectionDirty(this.worldPosition);
+            }
+            this.mekanism_covers$updateClientRender = false;
         }
     }
 

--- a/src/main/java/dev/lucaargolo/mekanismcovers/mixin/sodium/SodiumBlockRendererMixin.java
+++ b/src/main/java/dev/lucaargolo/mekanismcovers/mixin/sodium/SodiumBlockRendererMixin.java
@@ -18,7 +18,7 @@ public abstract class SodiumBlockRendererMixin extends AbstractBlockRenderContex
 
     @Shadow @Final private int[] vertexColors;
 
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/model/color/ColorProvider;getColors(Lnet/caffeinemc/mods/sodium/client/world/LevelSlice;Lnet/minecraft/core/BlockPos;Lnet/minecraft/core/BlockPos$MutableBlockPos;Ljava/lang/Object;Lnet/caffeinemc/mods/sodium/client/model/quad/ModelQuadView;[I)V", shift = At.Shift.AFTER), method = "colorizeQuad")
+    @Inject(at = @At(value = "INVOKE", target = "Lnet/caffeinemc/mods/sodium/client/model/color/ColorProvider;getColors", shift = At.Shift.AFTER), method = "colorizeQuad")
     public void putTranslucentVertexColor(MutableQuadViewImpl quad, int colorIndex, CallbackInfo ci) {
         if((quad.getColorIndex() == 1337 || quad.getColorIndex() == 1338) && MekanismCoversClient.isCoverTransparentFast() && this.state.getBlock() instanceof BlockTransmitter) {
             for (int i = 0; i < vertexColors.length; i++) {


### PR DESCRIPTION
A possible fix to issues I found building a 1.21.1 Java NeoForge server for my friends. 
This fixes (at least for me) the crash on sodium 0.8.x startup and a specific issue that may have been caused by another mod - when placing the covers, they did not render until another block placed next to them triggered the re-render.

This works for me fine but may need some more testing.